### PR TITLE
Add method for starting the process after deploying it

### DIFF
--- a/process-application/src/main/java/de/blogspot/wrongtracks/example/ExampleProcessApplication.java
+++ b/process-application/src/main/java/de/blogspot/wrongtracks/example/ExampleProcessApplication.java
@@ -1,6 +1,8 @@
 package de.blogspot.wrongtracks.example;
 
+import org.camunda.bpm.application.PostDeploy;
 import org.camunda.bpm.application.ProcessApplication;
+import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.extension.osgi.application.OSGiProcessApplication;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.blueprint.container.BlueprintContainer;
@@ -10,5 +12,10 @@ public class ExampleProcessApplication extends OSGiProcessApplication {
   
   public ExampleProcessApplication(BundleContext ctx, BlueprintContainer blueprintContainer) {
     super(ctx.getBundle(), blueprintContainer);
+  }
+
+  @PostDeploy
+  public void executeProcess(ProcessEngine processEngine){
+    processEngine.getRuntimeService().startProcessInstanceByKey("Process_1");
   }
 }


### PR DESCRIPTION
The original code was missing a method that starts the process after deploying it, so the BPMN was never executed.